### PR TITLE
removing mily.widgets.label_layout

### DIFF
--- a/bluesky_ui/widgets.py
+++ b/bluesky_ui/widgets.py
@@ -5,7 +5,7 @@ from event_model import DocumentNames
 
 from pyqtgraph.parametertree import ParameterTree
 
-from mily.widgets import (label_layout, vstacked_label,
+from mily.widgets import (vstacked_label,
                           hstacked_label, MISpin, MFSpin,
                           MetaDataEntry)
 
@@ -216,9 +216,21 @@ class Count(QtWidgets.QWidget):
         # float spinner
         self.delay_spin = MFSpin('delay')
         self.delay_spin.setRange(0, 60*60)  # maximum delay an hour
-        self.delay_spin.setDecimals(1)                 # only 0.1s precision from GUI
+        self.delay_spin.setDecimals(1)  # only 0.1s precision from GUI
         self.delay_spin.setSuffix('s')
-        hlayout.addLayout(label_layout('delay', False, self.delay_spin))
+        label_layout = QtWidgets.QHBoxLayout()
+        inner_layout = QtWidgets.QHBoxLayout()
+        cb = QtWidgets.QCheckBox()
+        label_layout.addWidget(QtWidgets.QCheckBox())
+        inner_layout.addWidget(QtWidgets.QLabel('delay'))
+        inner_layout.addWidget(self.delay_spin)
+        label_layout.addLayout(inner_layout)
+        label_layout.addStretch()
+        cb.setCheckable(True)
+        cb.stateChanged.connect(self.delay_spin.setEnabled)
+        cb.setChecked(False)
+        self.delay_spin.setEnabled(False)
+        hlayout.addLayout(label_layout)
         hlayout.addStretch()
         vlayout.addLayout(hlayout)
         # set up the detector selector


### PR DESCRIPTION
Sorry forgot to add this yesterday  .....

This is a partner to yesterdays mily PR#11. It moves the only reference to any of the deleted items from ``mily`` in ``bluesky-ui``. There is only one place that ``mily.label_layout`` was used, so I have transplanted the appropriate code from there to here. None of the other nuked items in ``mily`` are used in ``bluesky-ui`` that I could find.