### PR TITLE
Built-in plans gui

### DIFF
--- a/bluesky_ui/table_interface_examples.py
+++ b/bluesky_ui/table_interface_examples.py
@@ -55,27 +55,31 @@ class SimpleREfunctionWidget(MFunctionTableInterfaceWidget):
 
     '''
 
-    # NOTE I have made these 'class' variables as I am considering
-    # that we may want to make them traitlets for user config reasons.
-    detectors = [hw.det, hw.det1, hw.det2]
-    motors = [hw.motor, hw.motor1, hw.motor2]
-    default_rows = [
-        {'label': 'plan_1', 'det': hw.det, 'motor': hw.motor, 'start': 0,
-         'stop': 2, 'num_steps': 3},
-        {'label': 'plan_2', 'det': hw.det1, 'motor': hw.motor1, 'start': -3,
-         'stop': 3, 'num_steps': 7},
-        {'label': 'plan_3', 'det': hw.det2, 'motor': hw.motor2, 'start': -4,
-         'stop': 4, 'num_steps': 9}]
-
     def __init__(self, name, *args, **kwargs):
+        self.detectors = [hw.det, hw.det1, hw.det2]
+        self.motors = [hw.motor, hw.motor1, hw.motor2]
+
         _det_dict = {det.name: det for det in self.detectors}
         _motor_dict = {motor.name: motor for motor in self.motors}
-        self.editor_map = {'label': MText,
-                           'det': partialclass(MComboBox,
-                                               {'items': _det_dict}),
-                           'motor': partialclass(MComboBox,
-                                                 {'items': _motor_dict}),
-                           'start': MFSpin,
-                           'stop': MFSpin,
-                           'num_steps': MISpin}
-        super().__init__(simple_REfunction, name, *args, **kwargs)
+
+        default_parameters = [
+            {'label': 'plan_1', 'det': hw.det, 'motor': hw.motor, 'start': 0,
+             'stop': 2, 'num_steps': 3},
+            {'label': 'plan_2', 'det': hw.det1, 'motor': hw.motor1, 'start': 3,
+             'stop': 7, 'num_steps': 7},
+            {'label': 'plan_3', 'det': hw.det2, 'motor': hw.motor2, 'start': 4,
+             'stop': 10, 'num_steps': 9}]
+
+        table_editor_map = {'label': MText,
+                            'det': partialclass(MComboBox,
+                                                {'items': _det_dict}),
+                            'motor': partialclass(MComboBox,
+                                                  {'items': _motor_dict}),
+                            'start': MFSpin,
+                            'stop': MFSpin,
+                            'num_steps': MISpin}
+
+        super().__init__(simple_REfunction, name, *args,
+                         table_editor_map=table_editor_map,
+                         default_parameters=[{}, *default_parameters, {}],
+                         **kwargs)

--- a/bluesky_ui/table_interface_examples.py
+++ b/bluesky_ui/table_interface_examples.py
@@ -1,0 +1,81 @@
+from bluesky.plans import scan
+from bluesky.simulators import summarize_plan
+from mily.widgets import MText, MComboBox, MISpin, MFSpin
+from mily.table_interface import MTableInterfaceWidgetWithExport
+from ophyd.sim import hw
+
+hw = hw()
+
+
+def partialclass(cls, partial_kwargs):
+    '''Returns a partial class with 'partial_kwargs' values set
+
+
+    This function returns a class whereby any args/kwargs in the dictionary
+    ``partial_kwargs`` are set.
+
+    Parameters
+    ----------
+    partial_kwargs : dict
+        a dict mapping arg/kwarg parameters to values.
+    '''
+
+    class PartialClass(cls):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **partial_kwargs, **kwargs)
+    return PartialClass
+
+
+# simplest possible tableinterface RunEngine GUI example
+def simple_REfunction(label='label', det=hw.det, motor=hw.motor, start=0,
+                      stop=3, num_steps=3):
+    '''A simple function that can performs summarize_plan on a scan plan.'''
+
+    plan = scan([det], motor, start, stop, num_steps, md={'plan_label': label})
+    summarize_plan(plan)
+
+
+class SimpleREfunctionWidget(MTableInterfaceWidgetWithExport):
+    '''A ``MTableInterfaceWidgetWithExport`` for use with simple_REfunction.
+
+    Add custom ``detectors``, ``motors``, ``editor_map`` and ``default_rows``
+    attributes which contain some function specfic information and/or user
+    configurable information.
+
+   To run this example as a standalone window use the following:
+
+    ..code-block:: python
+
+        from bluesky_ui.table_interface_examples import SimpleREfunctionWidget
+        from PyQt5.QtWidgets import QApplication
+        app = QApplication([])
+        window = SimpleREfunctionWidget('simple_REfunction')
+        window.show()
+        app.exec_()
+
+    '''
+
+    # NOTE I have made these 'class' variables as I am considering
+    # that we may want to make them traitlets for user config reasons.
+    detectors = [hw.det, hw.det1, hw.det2]
+    motors = [hw.motor, hw.motor1, hw.motor2]
+    default_rows = [
+        {'label': 'plan_1', 'det': hw.det, 'motor': hw.motor, 'start': 0,
+         'stop': 2, 'num_steps': 3},
+        {'label': 'plan_2', 'det': hw.det1, 'motor': hw.motor1, 'start': -3,
+         'stop': 3, 'num_steps': 7},
+        {'label': 'plan_3', 'det': hw.det2, 'motor': hw.motor2, 'start': -4,
+         'stop': 4, 'num_steps': 9}]
+
+    def __init__(self, name, *args, **kwargs):
+        _det_dict = {det.name: det for det in self.detectors}
+        _motor_dict = {motor.name: motor for motor in self.motors}
+        self.editor_map = {'label': MText,
+                           'det': partialclass(MComboBox,
+                                               {'items': _det_dict}),
+                           'motor': partialclass(MComboBox,
+                                                 {'items': _motor_dict}),
+                           'start': MFSpin,
+                           'stop': MFSpin,
+                           'num_steps': MISpin}
+        super().__init__(simple_REfunction, name, *args, **kwargs)

--- a/bluesky_ui/table_interface_examples.py
+++ b/bluesky_ui/table_interface_examples.py
@@ -1,7 +1,7 @@
 from bluesky.plans import scan
 from bluesky.simulators import summarize_plan
 from mily.widgets import MText, MComboBox, MISpin, MFSpin
-from mily.table_interface import MTableInterfaceWidgetWithExport
+from mily.table_interface import MFunctionTableInterfaceWidget
 from ophyd.sim import hw
 
 hw = hw()
@@ -35,7 +35,7 @@ def simple_REfunction(label='label', det=hw.det, motor=hw.motor, start=0,
     summarize_plan(plan)
 
 
-class SimpleREfunctionWidget(MTableInterfaceWidgetWithExport):
+class SimpleREfunctionWidget(MFunctionTableInterfaceWidget):
     '''A ``MTableInterfaceWidgetWithExport`` for use with simple_REfunction.
 
     Add custom ``detectors``, ``motors``, ``editor_map`` and ``default_rows``

--- a/bluesky_ui/widgets.py
+++ b/bluesky_ui/widgets.py
@@ -104,12 +104,12 @@ class BsMvTableEditor(MTableInterfaceWidget):
     '''Table editor for plan_args following the ``mv`` plan_stub API.'''
     def __init__(self, *args, motors=[], **kwargs):
         self.motors = motors
-        self.editor_map = {'motor': partial(table_mcombobox_factory,
-                                            option_list=self.motors,
-                                            table=self,
-                                            key='motor'),
-                           'value': MFSpin}
-        super().__init__(*args, **kwargs)
+        table_editor_map = {'motor': partial(table_mcombobox_factory,
+                                             option_list=self.motors,
+                                             table=self,
+                                             key='motor'),
+                            'value': MFSpin}
+        super().__init__(*args, table_editor_map=table_editor_map, **kwargs)
 
 
 class BsScanTableEditor(MTableInterfaceWidget):
@@ -117,17 +117,19 @@ class BsScanTableEditor(MTableInterfaceWidget):
     def __init__(self, *args, detectors=[], motors=[], **kwargs):
         self.detectors = detectors
         self.motors = motors
-        self.prefix_editor_map = {'dets': partial(table_mselector_factory,
-                                                  option_list=self.detectors,
-                                                  vertical=False)}
-        self.editor_map = {'motor': partial(table_mcombobox_factory,
-                                            option_list=self.motors,
-                                            table=self,
-                                            key='motor'),
-                           'start': MFSpin,
-                           'stop': MFSpin}
-        self.suffix_editor_map = {'num': MISpin}
-        super().__init__(*args, **kwargs)
+        prefix_editor_map = {'dets': partial(table_mselector_factory,
+                                             option_list=self.detectors,
+                                             vertical=False)}
+        table_editor_map = {'motor': partial(table_mcombobox_factory,
+                                             option_list=self.motors,
+                                             table=self,
+                                             key='motor'),
+                            'start': MFSpin,
+                            'stop': MFSpin}
+        suffix_editor_map = {'num': MISpin}
+        super().__init__(*args, prefix_editor_map=prefix_editor_map,
+                         table_editor_map=table_editor_map,
+                         suffix_editor_map=suffix_editor_map, **kwargs)
 
 
 class BsGridTableEditor(MTableInterfaceWidget):
@@ -135,19 +137,20 @@ class BsGridTableEditor(MTableInterfaceWidget):
     def __init__(self, *args, detectors=[], motors=[], **kwargs):
         self.detectors = detectors
         self.motors = motors
-        self.prefix_editor_map = {'dets': partial(table_mselector_factory,
-                                                  option_list=self.detectors,
-                                                  vertical=False)}
-        self.editor_map = {'motor': partial(table_mcombobox_factory,
-                                            option_list=self.motors,
-                                            table=self,
-                                            key='motor'),
-                           'start': MFSpin,
-                           'stop': MFSpin,
-                           'num': MISpin,
-                           'snake': partial(bs_snake_editor_factory,
-                                            table=self)}
-        super().__init__(*args, **kwargs)
+        prefix_editor_map = {'dets': partial(table_mselector_factory,
+                                             option_list=self.detectors,
+                                             vertical=False)}
+        table_editor_map = {'motor': partial(table_mcombobox_factory,
+                                       option_list=self.motors,
+                                       table=self,
+                                       key='motor'),
+                      'start': MFSpin,
+                      'stop': MFSpin,
+                      'num': MISpin,
+                      'snake': partial(bs_snake_editor_factory,
+                                       table=self)}
+        super().__init__(*args, prefix_editor_map=prefix_editor_map,
+                         table_editor_map=table_editor_map, **kwargs)
 
 
 class MoverRanger(QtWidgets.QWidget):

--- a/bluesky_ui/widgets.py
+++ b/bluesky_ui/widgets.py
@@ -41,7 +41,7 @@ class UniqueValidator(QValidator):
         # https://stackoverflow.com/questions/34055174/qvalidator-fixup-issue
 
 
-def table_unique_mtest_factory(name, parent, table):
+def table_unique_mtext_factory(name, parent, table):
     '''An 'Editor Factory' for an ``MText`` widget to ensure unique values.
 
     This is designed to be used in an ``MTableInterfaceWidget`` where it


### PR DESCRIPTION
NOTE: This is built off of the changes in PR #3, prior to being moved from being a 'draft' we should have PR #3 merged and this re-based on master.  I have opened it to show why some of the ideas in PR#3 have been implemented, and to discuss if this general idea is a good one or not.

I intend that this PR will expand to include a table interface widget that has at least 3 columns: a label column for creating a human readable label for the row, a 'plan type' column for selecting one of the built-in plan types and a 'plan_args' column for entering the plan arguments corresponding to the selected 'plan_type'. 

At present it includes the 'editor widgets' for each plan type.

Some items to look at based on a code review meeting at NSLS-II:
[ ]  - what (if any) overlap is there with Ron's `plan factory` work?
[X]  - ensure 'start', 'stop' or 'value' items are within a motors limits.
[X]  - update columns that depend on another columns value when those columns are updated.
[X] - add mechanism for ensuring a column has only unique values.
[ ]  - generate a top level able 'widget' that has a 'label' column (for a human readable 'label'), a 'plan type' column (for selecting one of the built-in plans) and a 'plan_args' column (for inputting the plan args data, using the plan specific table widget as an editor). 
